### PR TITLE
Fix Session Ordering Issue

### DIFF
--- a/SwiftFest/AgendaViewController.swift
+++ b/SwiftFest/AgendaViewController.swift
@@ -131,7 +131,13 @@ private extension AgendaViewController.TableViewManager {
                                             count: currentDay.timeslots.count)
 
         for (index, timeslot) in currentDay.timeslots.enumerated() {
-            let sessionsForSection = sessions.filter { timeslot.sessionIds.contains($0.id) && !$0.title.isEmpty }
+			var sessionsForSection: [Session] = []
+			for sessionID in timeslot.sessionIds {
+				let session = sessions.filter { $0.id == sessionID && !$0.title.isEmpty }
+				if session.isEmpty == false {
+					sessionsForSection.append(session[0])
+				}
+			}
             sessionsBySection[index] = sessionsForSection
         }
 

--- a/SwiftFest/AgendaViewController.swift
+++ b/SwiftFest/AgendaViewController.swift
@@ -131,13 +131,13 @@ private extension AgendaViewController.TableViewManager {
                                             count: currentDay.timeslots.count)
 
         for (index, timeslot) in currentDay.timeslots.enumerated() {
-			var sessionsForSection: [Session] = []
-			for sessionID in timeslot.sessionIds {
-				let session = sessions.filter { $0.id == sessionID && !$0.title.isEmpty }
-				if session.isEmpty == false {
-					sessionsForSection.append(session[0])
-				}
-			}
+            var sessionsForSection: [Session] = []
+            for sessionID in timeslot.sessionIds {
+                let session = sessions.filter { $0.id == sessionID && !$0.title.isEmpty }
+                if session.isEmpty == false {
+                    sessionsForSection.append(session[0])
+                }
+            }
             sessionsBySection[index] = sessionsForSection
         }
 


### PR DESCRIPTION
This fixes [issue #45](https://github.com/SwiftFest/ios-app/issues/45)

The way sessions were being filtered into the table view was taking them in numerical order by their session ID. In one circumstance, the order of the sessions was not in numerical order, so it was being presented incorrectly. This fixes that.

The fix may not be pretty, but it gets the job done. I'm definitely open to suggestions if there is a better way to accomplish this.