### PR TITLE
Use readable width to make it easier to read on iPad

### DIFF
--- a/SwiftFest/Resources/Base.lproj/Main.storyboard
+++ b/SwiftFest/Resources/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Juu-Xm-yeN">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Juu-Xm-yeN">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
@@ -30,7 +30,7 @@
                                     <action selector="changeDay:" destination="BYZ-38-t0r" eventType="valueChanged" id="UJp-Qk-LIb"/>
                                 </connections>
                             </segmentedControl>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="j0g-kM-Oje">
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="j0g-kM-Oje">
                                 <rect key="frame" x="0.0" y="109" width="375" height="509"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                             </tableView>
@@ -68,7 +68,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="rAK-v5-Ldh">
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="rAK-v5-Ldh">
                                 <rect key="frame" x="0.0" y="64" width="375" height="554"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                             </tableView>
@@ -349,7 +349,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="300" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="aIi-Ui-zav">
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="300" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="aIi-Ui-zav">
                                 <rect key="frame" x="0.0" y="64" width="375" height="554"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                             </tableView>
@@ -387,7 +387,7 @@
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Uh2-Yw-dSU">
                                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                         <subviews>
-                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="jlf-Xh-su2">
+                                            <view contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="jlf-Xh-su2">
                                                 <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                             </view>
@@ -484,7 +484,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="300" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="o13-3G-D8Z">
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="300" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="o13-3G-D8Z">
                                 <rect key="frame" x="0.0" y="64" width="375" height="554"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                             </tableView>

--- a/SwiftFest/SessionDetailView.swift
+++ b/SwiftFest/SessionDetailView.swift
@@ -24,7 +24,7 @@ class SessionDetailView: UIView {
 
         addSubview(textView)
         textView.snp.makeConstraints {
-            $0.edges.equalToSuperview()
+            $0.edges.equalTo(readableContentGuide)
         }
     }
 

--- a/SwiftFest/SpeakerDetailView.xib
+++ b/SwiftFest/SpeakerDetailView.xib
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
         <capability name="Alignment constraints with different attributes" minToolsVersion="5.1"/>
+        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -13,35 +14,35 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="SpeakerDetailView" customModule="SwiftFest" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="365" height="830"/>
+        <view contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" id="iN0-l3-epB" customClass="SpeakerDetailView" customModule="SwiftFest" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="T8V-MO-iv0">
-                    <rect key="frame" x="0.0" y="0.0" width="365" height="830"/>
+                <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="T8V-MO-iv0">
+                    <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
                     <subviews>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3fG-kp-xQ7" userLabel="SpeakerView">
-                            <rect key="frame" x="0.0" y="0.0" width="365" height="217"/>
+                            <rect key="frame" x="0.0" y="0.0" width="414" height="217"/>
                             <subviews>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="g2y-gD-7UN" customClass="GradientView" customModule="SwiftFest" customModuleProvider="target">
-                                    <rect key="frame" x="0.0" y="0.0" width="365" height="217"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="217"/>
                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 </view>
                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="kFb-G9-7ZU">
-                                    <rect key="frame" x="122.5" y="24" width="120" height="120"/>
+                                    <rect key="frame" x="147.5" y="24" width="120" height="120"/>
                                     <constraints>
                                         <constraint firstAttribute="height" constant="120" id="qPb-po-Xcm"/>
                                         <constraint firstAttribute="width" constant="120" id="uae-um-eYW"/>
                                     </constraints>
                                 </imageView>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Susan Bennett" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oeQ-HS-40a">
-                                    <rect key="frame" x="92.5" y="152" width="181.5" height="33.5"/>
+                                    <rect key="frame" x="117.5" y="152" width="181" height="33.5"/>
                                     <fontDescription key="fontDescription" type="system" weight="medium" pointSize="28"/>
                                     <color key="textColor" name="White"/>
                                     <nil key="highlightedColor"/>
                                 </label>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Speaker Title" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="L7E-Un-plO">
-                                    <rect key="frame" x="15" y="191.5" width="335" height="20.5"/>
+                                    <rect key="frame" x="33" y="191.5" width="350" height="20.5"/>
                                     <constraints>
                                         <constraint firstAttribute="width" priority="750" constant="350" id="iBt-qh-bke"/>
                                     </constraints>
@@ -66,14 +67,15 @@
                             </constraints>
                         </view>
                         <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="EKt-37-GrQ">
-                            <rect key="frame" x="349" y="217" width="0.0" height="0.0"/>
+                            <rect key="frame" x="398" y="217" width="0.0" height="0.0"/>
                             <constraints>
                                 <constraint firstAttribute="height" priority="250" id="5Xz-GV-gpH"/>
                                 <constraint firstAttribute="width" priority="250" id="TcK-an-bTa"/>
                             </constraints>
                         </stackView>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="This is a bio that keeps going for many lines etc etc etc etc" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yfG-HD-Wn3">
-                            <rect key="frame" x="12" y="249.5" width="341" height="41"/>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" text="This is a bio that keeps going for many lines etc etc etc etc" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yfG-HD-Wn3">
+                            <rect key="frame" x="20" y="249.5" width="374" height="41"/>
+                            <viewLayoutGuide key="safeArea" id="TJu-td-xS9"/>
                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
@@ -82,13 +84,13 @@
                     <constraints>
                         <constraint firstItem="EKt-37-GrQ" firstAttribute="top" secondItem="L7E-Un-plO" secondAttribute="bottom" constant="5" id="9j0-4V-kaZ"/>
                         <constraint firstAttribute="bottom" secondItem="yfG-HD-Wn3" secondAttribute="bottom" constant="8" id="IVv-st-hV6"/>
-                        <constraint firstAttribute="trailing" secondItem="yfG-HD-Wn3" secondAttribute="trailing" constant="12" id="PAT-nD-H9g"/>
+                        <constraint firstItem="yfG-HD-Wn3" firstAttribute="trailing" secondItem="T8V-MO-iv0" secondAttribute="trailingMargin" id="PAT-nD-H9g"/>
                         <constraint firstItem="EKt-37-GrQ" firstAttribute="centerY" secondItem="3fG-kp-xQ7" secondAttribute="bottom" id="X4e-id-J6k"/>
                         <constraint firstAttribute="trailing" secondItem="3fG-kp-xQ7" secondAttribute="trailing" id="amZ-57-DHB"/>
                         <constraint firstItem="3fG-kp-xQ7" firstAttribute="leading" secondItem="T8V-MO-iv0" secondAttribute="leading" id="bbr-9n-mtc"/>
                         <constraint firstItem="3fG-kp-xQ7" firstAttribute="top" secondItem="T8V-MO-iv0" secondAttribute="top" id="ech-Sf-DXk"/>
-                        <constraint firstItem="3fG-kp-xQ7" firstAttribute="bottom" secondItem="yfG-HD-Wn3" secondAttribute="top" constant="-32.5" id="lIV-Zs-ugn"/>
-                        <constraint firstItem="yfG-HD-Wn3" firstAttribute="leading" secondItem="T8V-MO-iv0" secondAttribute="leading" constant="12" id="nuX-Gg-rkK"/>
+                        <constraint firstItem="yfG-HD-Wn3" firstAttribute="top" secondItem="3fG-kp-xQ7" secondAttribute="bottom" constant="32" id="lIV-Zs-ugn"/>
+                        <constraint firstItem="yfG-HD-Wn3" firstAttribute="leading" secondItem="T8V-MO-iv0" secondAttribute="leadingMargin" id="nuX-Gg-rkK"/>
                         <constraint firstItem="3fG-kp-xQ7" firstAttribute="trailing" secondItem="EKt-37-GrQ" secondAttribute="trailing" constant="16" id="qfg-sR-Ukq"/>
                     </constraints>
                 </scrollView>


### PR DESCRIPTION
This PR adds selects the “Follow Readable Width” checkbox in Interface Builder in a few places and uses the `readableContentGuide` of a view to create Auto Layout constraints in order to make the width of the text on some screens more readable on iPad. See screenshots below:
![simulator screen shot - ipad pro 12 9-inch 2nd generation - 2018-06-18 at 13 15 50](https://user-images.githubusercontent.com/147458/41551508-132516be-72fa-11e8-9c92-c3768fe6a41d.png)
![simulator screen shot - ipad pro 12 9-inch 2nd generation - 2018-06-18 at 13 16 00](https://user-images.githubusercontent.com/147458/41551509-13301b2c-72fa-11e8-804f-86d1c67aa40f.png)

